### PR TITLE
FastAPI needed root path of the deployment URL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
 
         stage('Run New Container') {
             steps {
-                sh 'docker run -d --name "calorie-tracker-backend" -p 8001:8001 "calorie-tracker-backend"'
+                sh 'docker run -d --name "calorie-tracker-backend" -p 8001:8001 "calorie-tracker-backend" --root-path "/api"'
             }
         }
     }


### PR DESCRIPTION
FastAPI needed to be informed that it is being deployed in a sub path of /api with nginx proxy configuration